### PR TITLE
fix: remove a type different from the runtime behavior

### DIFF
--- a/src/action-creator.ts
+++ b/src/action-creator.ts
@@ -18,13 +18,10 @@ export interface FSA<Payload = void> {
  * export const Login = actionCreator<string[]>("LOGIN");
  * Login(["foo", "bar"])
  */
-export type ActionCreator<Payload = void> = {
+export interface ActionCreator<Payload = void> {
   type: FluxType;
-} & (
-    Payload extends void ?
-    { (options?: ActionCreator.Options): FSA<Payload> } :
-    { (payload: Payload, options?: ActionCreator.Options): FSA<Payload> }
-  )
+  (payload: Payload, options?: ActionCreator.Options): FSA<Payload>;
+}
 
 export namespace ActionCreator {
   export interface Options {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,5 +1,5 @@
-import { actionCreator } from '../../src/action-creator';
-import { action } from '../../src/helpers';
+import { actionCreator } from "../../src/action-creator";
+import { action } from "../../src/helpers";
 
 // test: actionCreator
 const WithPayload = actionCreator<string[]>("payload");
@@ -9,13 +9,13 @@ WithPayload(["payload"]);
 WithPayload(["payload"], {
   error: false,
   meta: "",
-  namespace: "",
+  namespace: ""
 });
-NoPayload();
-NoPayload({
+NoPayload(void 0);
+NoPayload(void 0, {
   error: false,
   meta: "",
-  namespace: "",
+  namespace: ""
 });
 
 action(WithPayload, (_, action) => {


### PR DESCRIPTION
## What

- Revert https://github.com/sue71/vuex-typescript-fsa/pull/7

## Why

The pr makes a type different from the runtime behavior, and it can not be determined whether the omitted parameter is payload or not in run-time.