### PR TITLE
feat: namespaced action creator

### DIFF
--- a/src/action-creator.ts
+++ b/src/action-creator.ts
@@ -35,12 +35,26 @@ export namespace ActionCreator {
  * Factory function for create ActionCreator
  * @param type
  */
-export function actionCreator<Payload = void>(type: FluxType): ActionCreator<Payload> {
-  return Object.assign(
+export function actionCreatorFactory(
+  prefix: string | undefined
+): typeof actionCreator {
+  return (type: FluxType) => actionCreator(type, prefix);
+}
+
+/**
+ * Factory function for create ActionCreator
+ * @param type
+ */
+export function actionCreator<Payload = void>(
+  type: FluxType,
+  prefix: string | undefined = undefined
+): ActionCreator<Payload> {
+  return (Object.assign(
     (payload: Payload, options: ActionCreator.Options): FSA<Payload> => {
+      const namespace =
+        options && options.namespace ? options.namespace : prefix;
       return {
-        type:
-          options && options.namespace ? `${options.namespace}/${type}` : type,
+        type: namespace ? `${namespace}/${type}` : type,
         payload,
         error: options && options.error,
         meta: options && options.meta
@@ -49,5 +63,5 @@ export function actionCreator<Payload = void>(type: FluxType): ActionCreator<Pay
     {
       type
     }
-  ) as unknown as ActionCreator<Payload>;
+  ) as unknown) as ActionCreator<Payload>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { combineAction, action, combineMutation, mutation } from "./helpers";
-export { actionCreator } from "./action-creator";
+export { actionCreator, actionCreatorFactory } from "./action-creator";

--- a/test/action-creator.ts
+++ b/test/action-creator.ts
@@ -1,0 +1,51 @@
+import { actionCreator, actionCreatorFactory } from "../src";
+
+describe("#actionCreator", () => {
+  test("make FSA factory", () => {
+    const factory = actionCreatorFactory("prefix");
+    const createFSA = factory<string>("TYPE");
+    expect(createFSA("test")).toEqual({
+      type: "prefix/TYPE",
+      payload: "test",
+      error: undefined,
+      meta: undefined
+    });
+  });
+  test("make with prefix", () => {
+    const createFSA = actionCreator<string>("TYPE", "prefix");
+    expect(createFSA("test")).toEqual({
+      type: "prefix/TYPE",
+      payload: "test",
+      error: undefined,
+      meta: undefined
+    });
+  });
+  test("make with options", () => {
+    const createFSA = actionCreator<string>("TYPE");
+    expect(
+      createFSA("test", {
+        namespace: "prefix",
+        error: false,
+        meta: "meta"
+      })
+    ).toEqual({
+      type: "prefix/TYPE",
+      payload: "test",
+      error: false,
+      meta: "meta"
+    });
+  });
+});
+
+describe("#actionCreatorFactory", () => {
+  test("make FSA factory with namespace", () => {
+    const factory = actionCreatorFactory("prefix");
+    const createFSA = factory<string>("TYPE");
+    expect(createFSA("test")).toEqual({
+      type: "prefix/TYPE",
+      payload: "test",
+      error: undefined,
+      meta: undefined
+    });
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,5 +1,10 @@
-import { actionCreator } from "../src/action-creator";
-import { action, combineAction, combineMutation, mutation } from "../src";
+import {
+  action,
+  combineAction,
+  combineMutation,
+  mutation,
+  actionCreator
+} from "../src";
 import Vue from "vue";
 import Vuex, { Store } from "vuex";
 import { ActionObject } from "../src/helpers";

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,4 +1,4 @@
-import { actionCreator } from "../../src/action-creator";
+import { actionCreator, actionCreatorFactory } from "../../src/action-creator";
 import { action } from "../../src/helpers";
 
 // test: actionCreator
@@ -16,6 +16,17 @@ NoPayload(void 0, {
   error: false,
   meta: "",
   namespace: ""
+});
+
+// test: actionCreatorFactory
+const factory = actionCreatorFactory("namespace");
+const Namespaced = factory<string[]>("payload");
+
+Namespaced(["payload"]);
+
+// test: action
+action(Namespaced, (_, action) => {
+  action.payload.length;
 });
 
 action(WithPayload, (_, action) => {


### PR DESCRIPTION
## What

add actionCreatorFactory which can give a prefix to the type of FSA
see also https://github.com/aikoven/typescript-fsa#actions-with-type-prefix

## Why

This is useful to use namespaced modules