### PR TITLE
feat: namespaced mapper

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,38 +1,7 @@
-import { ActionContext, ActionTree, MutationTree, Store } from "vuex";
-import { FSA, ActionCreator } from "./action-creator";
-
-/**
- * Definition for annotating type parameter
- */
-export type PayloadType<T> = T extends ActionCreator<infer R> ? R : never;
-export type ReturnType<T> = T extends (...args: any[]) => infer R ? R : never;
-
-/**
- * Enhanced type definition for Vuex ActionHandler
- */
-export type ActionHandler<S, R, P> = (
-  this: Store<R>,
-  injectee: ActionContext<S, R>,
-  payload: P
-) => any;
-
-/**
- * Enhanced type definition for Vuex ActionObject
- */
-export interface ActionObject<S, R, P> {
-  root?: boolean;
-  handler: ActionHandler<S, R, P>;
-}
-
-/**
- * Enhanced type definition for Vuex Action
- */
-export type Action<S, R, P> = ActionHandler<S, R, P> | ActionObject<S, R, P>;
-
-/**
- * Enhanced type definition for Vuex Mutation
- */
-export type Mutation<S, P> = (this: Store<S>, state: S, payload: P) => void;
+import { ActionTree, MutationTree } from "vuex";
+import { ActionCreator, PayloadType } from "./action-creator";
+import { Action, Mutation } from "./types/vuex";
+import { FSA } from "./types/fsa";
 
 /**
  * Create action handler with type annotation

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { combineAction, action, combineMutation, mutation } from "./helpers";
 export { actionCreator, actionCreatorFactory } from "./action-creator";
+export { mapActions, mapMutations, createNamespacedHelpers } from "./mapper";

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -1,0 +1,52 @@
+import { ActionCreator, PayloadType } from "./action-creator";
+
+export type Mappable = Record<string, ActionCreator<any>>;
+
+export function mapActions<T extends Mappable>(
+  map: T,
+  namespace?: string
+): {
+  [K in keyof T]: (payload: PayloadType<T[K]>) => Promise<object> | object
+} {
+  return Object.keys(map)
+    .map(v => ({ key: v, action: map[v] }))
+    .reduce((acc, item) => {
+      const action = item.action;
+      return {
+        ...acc,
+        [item.key]: function(this: any, payload: any) {
+          return this.$store.dispatch(
+            action(payload, {
+              namespace: namespace || action.namespace
+            })
+          );
+        }
+      };
+    }, {}) as any;
+}
+
+export function mapMutations<T extends Mappable>(
+  map: T,
+  namespace?: string
+): { [K in keyof T]: (payload: PayloadType<T[K]>) => void } {
+  return Object.keys(map)
+    .map(v => ({ key: v, action: map[v] }))
+    .reduce((acc, item) => {
+      const action = item.action;
+      return {
+        ...acc,
+        [item.key]: function(this: any, payload: any) {
+          return this.$store.commit(
+            action(payload, {
+              namespace: namespace || action.namespace
+            })
+          );
+        }
+      };
+    }, {}) as any;
+}
+
+export const createNamespacedHelpers = (namespace: string) => ({
+  mapMutations: <T extends Mappable>(map: T) => mapMutations(map, namespace),
+  mapActions: <T extends Mappable>(map: T) => mapActions(map, namespace)
+});

--- a/src/types/fsa.ts
+++ b/src/types/fsa.ts
@@ -1,0 +1,10 @@
+export type FluxType = string;
+/**
+ * Action conformed to FSA
+ */
+export interface FSA<Payload = void> {
+  readonly type: FluxType;
+  payload: Payload;
+  error?: boolean;
+  meta?: any;
+}

--- a/src/types/vuex.ts
+++ b/src/types/vuex.ts
@@ -1,0 +1,28 @@
+import { ActionContext, Store } from "vuex";
+
+/**
+ * Enhanced type definition for Vuex ActionHandler
+ */
+export type ActionHandler<S, R, P> = (
+  this: Store<R>,
+  injectee: ActionContext<S, R>,
+  payload: P
+) => any;
+
+/**
+ * Enhanced type definition for Vuex ActionObject
+ */
+export interface ActionObject<S, R, P> {
+  root?: boolean;
+  handler: ActionHandler<S, R, P>;
+}
+
+/**
+ * Enhanced type definition for Vuex Action
+ */
+export type Action<S, R, P> = ActionHandler<S, R, P> | ActionObject<S, R, P>;
+
+/**
+ * Enhanced type definition for Vuex Mutation
+ */
+export type Mutation<S, P> = (this: Store<S>, state: S, payload: P) => void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * makeType with prefix
+ * @param type
+ * @param prefix
+ */
+export function makeType(type: string, prefix?: string): string {
+  if (prefix) {
+    return `${prefix}/${type}`;
+  }
+  return type;
+}

--- a/test/action-creator.ts
+++ b/test/action-creator.ts
@@ -1,9 +1,26 @@
 import { actionCreator, actionCreatorFactory } from "../src";
 
 describe("#actionCreator", () => {
-  test("make FSA factory", () => {
-    const factory = actionCreatorFactory("prefix");
-    const createFSA = factory<string>("TYPE");
+  test("make action creator", () => {
+    const creator = actionCreatorFactory({
+      prefix: "prefix",
+      namespace: "namespace"
+    });
+    const createFSA = creator<string>("TYPE");
+    expect(createFSA.namespace).toEqual("namespace");
+    expect(createFSA.type).toEqual("prefix/TYPE");
+  });
+  test("make action creator with namespace", () => {
+    const creator = actionCreatorFactory("namespace");
+    const createFSA = creator<string>("TYPE");
+    expect(createFSA.namespace).toEqual("namespace");
+    expect(createFSA.type).toEqual("TYPE");
+  });
+  test("make fsa", () => {
+    const createFSA = actionCreator<string>("TYPE", {
+      prefix: "prefix",
+      namespace: "namespace"
+    });
     expect(createFSA("test")).toEqual({
       type: "prefix/TYPE",
       payload: "test",
@@ -11,41 +28,21 @@ describe("#actionCreator", () => {
       meta: undefined
     });
   });
-  test("make with prefix", () => {
-    const createFSA = actionCreator<string>("TYPE", "prefix");
-    expect(createFSA("test")).toEqual({
-      type: "prefix/TYPE",
-      payload: "test",
-      error: undefined,
-      meta: undefined
-    });
-  });
-  test("make with options", () => {
+  test("make fsa with options", () => {
     const createFSA = actionCreator<string>("TYPE");
+    expect(createFSA.namespace).toEqual(undefined);
+    expect(createFSA.type).toEqual("TYPE");
     expect(
       createFSA("test", {
-        namespace: "prefix",
+        namespace: "namespace",
         error: false,
         meta: "meta"
       })
     ).toEqual({
-      type: "prefix/TYPE",
+      type: "namespace/TYPE",
       payload: "test",
       error: false,
       meta: "meta"
-    });
-  });
-});
-
-describe("#actionCreatorFactory", () => {
-  test("make FSA factory with namespace", () => {
-    const factory = actionCreatorFactory("prefix");
-    const createFSA = factory<string>("TYPE");
-    expect(createFSA("test")).toEqual({
-      type: "prefix/TYPE",
-      payload: "test",
-      error: undefined,
-      meta: undefined
     });
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -7,7 +7,7 @@ import {
 } from "../src";
 import Vue from "vue";
 import Vuex, { Store } from "vuex";
-import { ActionObject } from "../src/helpers";
+import { ActionObject } from "../src/types/vuex";
 
 describe("helpers", () => {
   const Action = actionCreator<string[]>("ACTION");

--- a/test/mapper.ts
+++ b/test/mapper.ts
@@ -1,0 +1,109 @@
+import {
+  actionCreator,
+  mapActions,
+  createNamespacedHelpers,
+  mapMutations
+} from "../src";
+import Vue from "vue";
+import Vuex, { Store, Module } from "vuex";
+
+describe("mapper", () => {
+  const Action = actionCreator("action");
+  const NamespacedAction = actionCreator("action", {
+    namespace: "b"
+  });
+
+  const root: Module<{ value: string }, any> = {
+    modules: {
+      a: {
+        namespaced: false,
+        actions: {
+          action: jest.fn() as any
+        },
+        mutations: {
+          action: jest.fn() as any
+        }
+      },
+      b: {
+        namespaced: true,
+        actions: {
+          action: jest.fn() as any
+        },
+        mutations: {
+          action: jest.fn() as any
+        }
+      }
+    }
+  };
+
+  Vue.use(Vuex);
+
+  const namespacedHelper = createNamespacedHelpers("b");
+  const store = new Store<any>(root);
+
+  const view = new Vue({
+    store,
+    methods: {
+      ...mapActions({
+        action: Action
+      }),
+      ...namespacedHelper.mapActions({
+        namespacedAction: Action
+      }),
+      ...mapActions({
+        fixedNamespacedAction: NamespacedAction
+      }),
+      ...mapMutations({
+        mutation: Action
+      }),
+      ...namespacedHelper.mapMutations({
+        namespacedMutation: Action
+      }),
+      ...mapMutations({
+        fixedNamespacedMutation: NamespacedAction
+      })
+    }
+  });
+
+  describe("simple module", () => {
+    test("map action", () => {
+      expect(view.action).toBeDefined();
+    });
+    test("map mutation", () => {
+      expect(view.mutation).toBeDefined();
+    });
+    test("dispatch action", () => {
+      view.action();
+      expect(root.modules!.a!.actions!["action"]).toHaveBeenCalled();
+    });
+    test("dispatch mutation", () => {
+      view.mutation();
+      expect(root.modules!.a!.mutations!["action"]).toHaveBeenCalled();
+    });
+  });
+
+  describe("namespaced module", () => {
+    test("map action", () => {
+      expect(view.namespacedAction).toBeDefined();
+    });
+    test("map mutation", () => {
+      expect(view.namespacedMutation).toBeDefined();
+    });
+    test("disptch action", () => {
+      view.namespacedAction();
+      expect(root.modules!.b!.actions!["action"]).toHaveBeenCalled();
+    });
+    test("dispatch action with fixed namespace", () => {
+      view.fixedNamespacedAction();
+      expect(root.modules!.b!.actions!["action"]).toHaveBeenCalled();
+    });
+    test("dispatch mutation", () => {
+      view.namespacedMutation();
+      expect(root.modules!.b!.mutations!["action"]).toHaveBeenCalled();
+    });
+    test("dispatch mutation with fixed namespace", () => {
+      view.fixedNamespacedAction();
+      expect(root.modules!.b!.mutations!["action"]).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,5 +1,11 @@
-import { actionCreator, actionCreatorFactory } from "../../src/action-creator";
+import Vue from "vue";
+import { actionCreatorFactory, actionCreator } from "../../src/action-creator";
 import { action } from "../../src/helpers";
+import {
+  mapActions,
+  mapMutations,
+  createNamespacedHelpers
+} from "../../src/mapper";
 
 // test: actionCreator
 const WithPayload = actionCreator<string[]>("payload");
@@ -19,8 +25,11 @@ NoPayload(void 0, {
 });
 
 // test: actionCreatorFactory
-const factory = actionCreatorFactory("namespace");
-const Namespaced = factory<string[]>("payload");
+const namespacedActionCreator = actionCreatorFactory({
+  namespace: "ns",
+  prefix: "prefix"
+});
+const Namespaced = namespacedActionCreator<string[]>("payload");
 
 Namespaced(["payload"]);
 
@@ -35,4 +44,19 @@ action(WithPayload, (_, action) => {
 
 action(NoPayload, (_, action) => {
   action.payload;
+});
+
+const namespacedHelper = createNamespacedHelpers("ns");
+
+// test: mapper
+Vue.extend({
+  methods: {
+    ...mapActions({ action: WithPayload }),
+    ...mapMutations({ mutation: WithPayload }),
+    ...namespacedHelper.mapActions({ namespacedAction: WithPayload }),
+    callAction() {
+      this.action(["test"]);
+      this.mutation(["test"]);
+    }
+  }
 });


### PR DESCRIPTION
- Add `namespace` options for `actionCreatorFactory` to fix the namespace of FSA
- Add map** which uses the namespace of FSA

```
const someAction = actionCreator<string>("TYPE");
Vue.extend({
  methods: {
    ...mapActions({ action: someAction }),
    ...mapMutations({ mutation: someAction }),
    someMethod() {
      this.action(["foo"]);
      this.mutation(["bar"]);
    }
  }
});
```